### PR TITLE
Improve Qwen Model's Structured Output Capabilities

### DIFF
--- a/docs/chat.ipynb
+++ b/docs/chat.ipynb
@@ -47,6 +47,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
    "id": "433e8d2b-9519-4b49-b2c4-7ab65b046c94",
    "metadata": {
     "ExecuteTime": {
@@ -54,15 +55,14 @@
      "start_time": "2025-05-22T10:10:30.815918Z"
     }
    },
+   "outputs": [],
    "source": [
     "import getpass\n",
     "import os\n",
     "\n",
     "if not os.getenv(\"DASHSCOPE_API_KEY\"):\n",
     "    os.environ[\"DASHSCOPE_API_KEY\"] = getpass.getpass(\"Enter your Dashscope API key: \")"
-   ],
-   "outputs": [],
-   "execution_count": 2
+   ]
   },
   {
    "cell_type": "markdown",
@@ -76,6 +76,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
    "id": "652d6238-1f87-422a-b135-f5abbb8652fc",
    "metadata": {
     "ExecuteTime": {
@@ -83,9 +84,6 @@
      "start_time": "2025-05-23T08:31:15.041536Z"
     }
    },
-   "source": [
-    "%pip install -qU langchain-qwq"
-   ],
    "outputs": [
     {
      "name": "stdout",
@@ -95,24 +93,28 @@
      ]
     }
    ],
-   "execution_count": 5
+   "source": [
+    "%pip install -qU langchain-qwq"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "To use it with documentation, i.e. with running this notebook, you need to install the docs dependencies:",
-   "id": "f73787ee6beb990a"
+   "id": "f73787ee6beb990a",
+   "metadata": {},
+   "source": [
+    "To use it with documentation, i.e. with running this notebook, you need to install the docs dependencies:"
+   ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f971daf8164074f8",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-05-23T11:08:55.073917Z",
      "start_time": "2025-05-23T11:08:54.039443Z"
     }
    },
-   "cell_type": "code",
-   "source": "%pip install -qU \"langchain-qwq[docs]\"",
-   "id": "f971daf8164074f8",
    "outputs": [
     {
      "name": "stdout",
@@ -122,7 +124,9 @@
      ]
     }
    ],
-   "execution_count": 1
+   "source": [
+    "%pip install -qU \"langchain-qwq[docs]\""
+   ]
   },
   {
    "cell_type": "markdown",
@@ -136,6 +140,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 6,
    "id": "cb09c344-1836-4e0c-acf8-11d13ac1dbae",
    "metadata": {
     "ExecuteTime": {
@@ -143,6 +148,7 @@
      "start_time": "2025-05-22T10:13:03.269885Z"
     }
    },
+   "outputs": [],
    "source": [
     "from langchain_qwq import ChatQwQ\n",
     "\n",
@@ -154,9 +160,7 @@
     "    max_retries=2,\n",
     "    # other params...\n",
     ")"
-   ],
-   "outputs": [],
-   "execution_count": 6
+   ]
   },
   {
    "cell_type": "markdown",
@@ -272,6 +276,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 7,
    "id": "6fe685eee2c9bbec",
    "metadata": {
     "ExecuteTime": {
@@ -279,6 +284,18 @@
      "start_time": "2025-05-22T10:13:11.154570Z"
     }
    },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "TranslationOutput(translation='Ich liebe Programmieren.', confidence=0.95)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from langchain_core.prompts import ChatPromptTemplate\n",
     "from pydantic import BaseModel\n",
@@ -289,7 +306,7 @@
     "    confidence: float\n",
     "\n",
     "\n",
-    "llm_with_structured_output = llm.with_structured_output(TranslationOutput)\n",
+    "llm_with_structured_output = llm.with_structured_output(TranslationOutput) # attention it! qwq model don't support json mode  # noqa: E501\n",
     "\n",
     "\n",
     "prompt = ChatPromptTemplate(\n",
@@ -311,20 +328,7 @@
     "        \"input\": \"I love programming.\",\n",
     "    }\n",
     ")"
-   ],
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "TranslationOutput(translation='Ich liebe Programmieren.', confidence=0.95)"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 7
+   ]
   },
   {
    "cell_type": "markdown",
@@ -344,6 +348,7 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
    "id": "4f9cfb5f",
    "metadata": {
     "ExecuteTime": {
@@ -351,13 +356,6 @@
      "start_time": "2025-05-22T10:12:04.966787Z"
     }
    },
-   "source": [
-    "from langchain_qwq import ChatQwen\n",
-    "\n",
-    "model = ChatQwen(model=\"qwen3-32b\", thinking_budget=100)\n",
-    "\n",
-    "model.invoke(\"What is love?\")"
-   ],
    "outputs": [
     {
      "data": {
@@ -370,7 +368,13 @@
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 5
+   "source": [
+    "from langchain_qwq import ChatQwen\n",
+    "\n",
+    "model = ChatQwen(model=\"qwen3-32b\", thinking_budget=100)\n",
+    "\n",
+    "model.invoke(\"What is love?\")"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/langchain_qwq/chat_models.py
+++ b/langchain_qwq/chat_models.py
@@ -1,6 +1,7 @@
 """Integration for Qwen QwQ and Qwen3  with thinking chat models."""
 
 from json import JSONDecodeError
+from operator import itemgetter
 from typing import (
     Any,
     AsyncIterator,
@@ -21,7 +22,7 @@ from langchain_core.callbacks import (
     CallbackManagerForLLMRun,
 )
 from langchain_core.language_models import LanguageModelInput
-from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage, ToolCall
+from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 from langchain_core.runnables import Runnable
 from langchain_core.utils import from_env, secret_from_env
@@ -264,73 +265,12 @@ class ChatQwQ(BaseChatOpenAI):
         run_manager: Optional[CallbackManagerForLLMRun] = None,
         **kwargs: Any,
     ) -> Iterator[ChatGenerationChunk]:
-        from langchain_core.messages import AIMessageChunk
-
-        # Store the original __add__ method
-        original_add = AIMessageChunk.__add__
-
-        # Helper function to check if a tool call is valid
-        def is_valid_tool_call(tc: ToolCall) -> bool:
-            # Filter out invalid/incomplete tool calls
-            if not tc:
-                return False
-
-            # Check that we have an ID
-            if not tc.get("id"):
-                return False
-
-            # Check that we have a name
-            if tc.get("name") is None and tc.get("type") == "function":
-                return False
-
-            # Check for valid args
-            args = tc.get("args")
-            if args is None or args == "}" or args == "{}}":
-                return False
-
-            return True
-
-        # Create a patched version that ensures tool_calls are preserved
-        def patched_add(self: AIMessageChunk, other: AIMessageChunk) -> AIMessageChunk:
-            if not isinstance(result := original_add(self, other), AIMessageChunk):
-                raise ValueError("Result is not an AIMessageChunk")
-
-            # Ensure tool_calls are preserved across additions
-            if hasattr(self, "tool_calls") and self.tool_calls:
-                if not hasattr(result, "tool_calls") or not result.tool_calls:
-                    result.tool_calls = [
-                        tc for tc in self.tool_calls if is_valid_tool_call(tc)
-                    ]
-
-            if hasattr(other, "tool_calls") and other.tool_calls:
-                if not hasattr(result, "tool_calls"):
-                    result.tool_calls = [
-                        tc for tc in other.tool_calls if is_valid_tool_call(tc)
-                    ]
-                else:
-                    # Merge unique tool calls, filtering out invalid ones
-                    existing_ids = {tc.get("id", "") for tc in result.tool_calls}
-                    for tc in other.tool_calls:
-                        if tc.get("id", "") not in existing_ids and is_valid_tool_call(
-                            tc
-                        ):
-                            result.tool_calls.append(tc)
-
-            return result
-
-        # Monkey patch the __add__ method
-        AIMessageChunk.__add__ = patched_add  # type: ignore
-
-        try:
-            kwargs["stream_options"] = {"include_usage": True}
-            # Original streaming
-            for chunk in super()._stream(
-                messages, stop=stop, run_manager=run_manager, **kwargs
-            ):
-                yield chunk
-        finally:
-            # Restore the original method
-            AIMessageChunk.__add__ = original_add  # type: ignore
+        kwargs["stream_options"] = {"include_usage": True}
+        # Original streaming
+        for chunk in super()._stream(
+            messages, stop=stop, run_manager=run_manager, **kwargs
+        ):
+            yield chunk
 
     def _generate(
         self,
@@ -528,73 +468,12 @@ class ChatQwQ(BaseChatOpenAI):
         run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
         **kwargs: Any,
     ) -> AsyncIterator[ChatGenerationChunk]:
-        from langchain_core.messages import AIMessageChunk
-
-        # Store the original __add__ method
-        original_add = AIMessageChunk.__add__
-
-        # Helper function to check if a tool call is valid
-        def is_valid_tool_call(tc: ToolCall) -> bool:
-            # Filter out invalid/incomplete tool calls
-            if not tc:
-                return False
-
-            # Check that we have an ID
-            if not tc.get("id"):
-                return False
-
-            # Check that we have a name
-            if tc.get("name") is None and tc.get("type") == "function":
-                return False
-
-            # Check for valid args
-            args = tc.get("args")
-            if args is None or args == "}" or args == "{}}":
-                return False
-
-            return True
-
-        # Create a patched version that ensures tool_calls are preserved
-        def patched_add(self: AIMessageChunk, other: AIMessageChunk) -> AIMessageChunk:
-            if not isinstance(result := original_add(self, other), AIMessageChunk):
-                raise ValueError("Result is not an AIMessageChunk")
-
-            # Ensure tool_calls are preserved across additions
-            if hasattr(self, "tool_calls") and self.tool_calls:
-                if not hasattr(result, "tool_calls") or not result.tool_calls:
-                    result.tool_calls = [
-                        tc for tc in self.tool_calls if is_valid_tool_call(tc)
-                    ]
-
-            if hasattr(other, "tool_calls") and other.tool_calls:
-                if not hasattr(result, "tool_calls"):
-                    result.tool_calls = [
-                        tc for tc in other.tool_calls if is_valid_tool_call(tc)
-                    ]
-                else:
-                    # Merge unique tool calls, filtering out invalid ones
-                    existing_ids = {tc.get("id", "") for tc in result.tool_calls}
-                    for tc in other.tool_calls:
-                        if tc.get("id", "") not in existing_ids and is_valid_tool_call(
-                            tc
-                        ):
-                            result.tool_calls.append(tc)
-
-            return result
-
-        # Monkey patch the __add__ method
-        AIMessageChunk.__add__ = patched_add  # type: ignore
-
-        try:
-            kwargs["stream_options"] = {"include_usage": True}
-            # Original async streaming
-            async for chunk in super()._astream(
-                messages, stop=stop, run_manager=run_manager, **kwargs
-            ):
-                yield chunk
-        finally:
-            # Restore the original method
-            AIMessageChunk.__add__ = original_add  # type: ignore
+        kwargs["stream_options"] = {"include_usage": True}
+        # Original async streaming
+        async for chunk in super()._astream(
+            messages, stop=stop, run_manager=run_manager, **kwargs
+        ):
+            yield chunk
 
     def with_structured_output(
         self,
@@ -624,194 +503,272 @@ class ChatQwQ(BaseChatOpenAI):
             A runnable that returns outputs formatted according to the given schema.
         """
         )
-        import json
-        import re
+        if method == "json_schema" or method == "json_mode":
+            import json
+            import re
 
-        from langchain_core.messages import HumanMessage, SystemMessage
-        from langchain_core.output_parsers import BaseOutputParser
-        from langchain_core.runnables import RunnableLambda
-        from langchain_core.utils.function_calling import convert_to_json_schema
+            from langchain_core.messages import HumanMessage, SystemMessage
+            from langchain_core.output_parsers import BaseOutputParser
+            from langchain_core.runnables import RunnableLambda
+            from langchain_core.utils.function_calling import convert_to_json_schema
 
-        if strict is None:
-            strict = True
+            if strict is None:
+                strict = True
 
-        if schema is None:
-            if method != "json_mode":
-                raise ValueError(
-                    "schema must be provided when method is not 'json_mode'"
-                )
-            schema_dict = {}
-            schema_name = "CustomOutput"
-            output_cls = None
-        else:
-            # Extract schema information using convert_to_json_schema
-            try:
-                schema_dict = convert_to_json_schema(schema)
-                if isinstance(schema, type) and is_basemodel_subclass(schema):
-                    schema_name = schema.__name__
-                    output_cls = schema
-                elif isinstance(schema, dict):
-                    schema_name = schema.get("title", "CustomOutput")
-                    output_cls = None
-                else:
-                    schema_name = getattr(schema, "__name__", "CustomOutput")
-                    output_cls = None
-            except Exception:
-                # Fallback for cases where convert_to_json_schema fails
-                if isinstance(schema, type) and is_basemodel_subclass(schema):
-                    if hasattr(schema, "model_json_schema"):
-                        schema_dict = schema.model_json_schema()  # Pydantic v2
-                    elif hasattr(schema, "schema"):
-                        schema_dict = schema.schema()  # Pydantic v1
-                    else:
-                        raise ValueError(f"Unsupported Pydantic model: {schema}")
-                    schema_name = schema.__name__
-                    output_cls = schema
-                elif isinstance(schema, dict):
-                    schema_dict = schema
-                    schema_name = schema_dict.get("title", "CustomOutput")
-                    output_cls = None
-                else:
-                    raise ValueError(f"Unsupported schema type: {type(schema)}")
-
-        # Create a custom output parser
-        class StructuredOutputParser(BaseOutputParser[Any]):
-            """Parser for structured output from QwQ."""
-
-            def parse(self, text: str) -> Any:
-                """Parse the output and convert to the target format."""
+            if schema is None:
+                if method != "json_mode":
+                    raise ValueError(
+                        "schema must be provided when method is not 'json_mode'"
+                    )
+                schema_dict = {}
+                schema_name = "CustomOutput"
+                output_cls = None
+            else:
+                # Extract schema information using convert_to_json_schema
                 try:
-                    # Try to parse as JSON
+                    schema_dict = convert_to_json_schema(schema)
+                    if isinstance(schema, type) and is_basemodel_subclass(schema):
+                        schema_name = schema.__name__
+                        output_cls = schema
+                    elif isinstance(schema, dict):
+                        schema_name = schema.get("title", "CustomOutput")
+                        output_cls = None
+                    else:
+                        schema_name = getattr(schema, "__name__", "CustomOutput")
+                        output_cls = None
+                except Exception:
+                    # Fallback for cases where convert_to_json_schema fails
+                    if isinstance(schema, type) and is_basemodel_subclass(schema):
+                        if hasattr(schema, "model_json_schema"):
+                            schema_dict = schema.model_json_schema()  # Pydantic v2
+                        elif hasattr(schema, "schema"):
+                            schema_dict = schema.schema()  # Pydantic v1
+                        else:
+                            raise ValueError(f"Unsupported Pydantic model: {schema}")
+                        schema_name = schema.__name__
+                        output_cls = schema
+                    elif isinstance(schema, dict):
+                        schema_dict = schema
+                        schema_name = schema_dict.get("title", "CustomOutput")
+                        output_cls = None
+                    else:
+                        raise ValueError(f"Unsupported schema type: {type(schema)}")
+
+            # Create a custom output parser
+            class StructuredOutputParser(BaseOutputParser[Any]):
+                """Parser for structured output from QwQ."""
+
+                def parse(self, text: str) -> Any:
+                    """Parse the output and convert to the target format."""
                     try:
-                        parsed = json.loads(text)
-                    except json.JSONDecodeError:
-                        # Try with regex
-                        json_match = re.search(r"(\{.*\})", text, re.DOTALL)
-                        if json_match:
-                            try:
-                                parsed = json.loads(json_match.group(1))
-                            except json.JSONDecodeError:
-                                # Try JSON repair
+                        # Try to parse as JSON
+                        try:
+                            parsed = json.loads(text)
+                        except json.JSONDecodeError:
+                            # Try with regex
+                            json_match = re.search(r"(\{.*\})", text, re.DOTALL)
+                            if json_match:
+                                try:
+                                    parsed = json.loads(json_match.group(1))
+                                except json.JSONDecodeError:
+                                    # Try JSON repair
+                                    import json_repair as json_repair_lib
+
+                                    parsed = json_repair_lib.loads(json_match.group(1))
+                            else:
+                                # Try JSON repair on whole text
                                 import json_repair as json_repair_lib
 
-                                parsed = json_repair_lib.loads(json_match.group(1))
-                        else:
-                            # Try JSON repair on whole text
-                            import json_repair as json_repair_lib
+                                parsed = json_repair_lib.loads(text)
 
-                            parsed = json_repair_lib.loads(text)
+                        # Validate with Pydantic if needed
+                        if output_cls and is_basemodel_subclass(output_cls):
+                            if hasattr(output_cls, "model_validate"):
+                                return output_cls.model_validate(parsed)
+                            elif hasattr(output_cls, "parse_obj"):
+                                return output_cls.parse_obj(parsed)
+                            else:
+                                raise ValueError(
+                                    "Unsupported Pydantic validation method"
+                                )
+                        return parsed
+                    except Exception as e:
+                        if strict:
+                            raise ValueError(f"Failed to parse output: {str(e)}")
+                        return text
 
-                    # Validate with Pydantic if needed
-                    if output_cls and is_basemodel_subclass(output_cls):
-                        if hasattr(output_cls, "model_validate"):
-                            return output_cls.model_validate(parsed)
-                        elif hasattr(output_cls, "parse_obj"):
-                            return output_cls.parse_obj(parsed)
-                        else:
-                            raise ValueError("Unsupported Pydantic validation method")
-                    return parsed
-                except Exception as e:
-                    if strict:
-                        raise ValueError(f"Failed to parse output: {str(e)}")
-                    return text
+            # Create system prompt for JSON output
+            system_template = (
+                """You are a helpful assistant that always responds with"""
+                """JSON that matches this schema:
+        ```json
+        {schema}
+        ```
 
-        # Create system prompt for JSON output
-        system_template = (
-            """You are a helpful assistant that always responds with"""
-            """JSON that matches this schema:
-    ```json
-    {schema}
-    ```
+        Follow these rules:
+        1. Your entire response must be valid JSON that adheres to the schema above
+        2. Do not include any explanations, preambles, or text outside the JSON
+        3. Do not include markdown formatting such as ```json or ``` around the JSON
+        4. Make sure all required fields in the schema are included
+        5. Use the correct data types for each field as specified in the schema
+        6. If boolean values are required, use true or false (lowercase without quotes)
+        7. If integer values are required, don't use quotes around them
 
-    Follow these rules:
-    1. Your entire response must be valid JSON that adheres to the schema above
-    2. Do not include any explanations, preambles, or text outside the JSON
-    3. Do not include markdown formatting such as ```json or ``` around the JSON
-    4. Make sure all required fields in the schema are included
-    5. Use the correct data types for each field as specified in the schema
-    6. If boolean values are required, use true or false (lowercase without quotes)
-    7. If integer values are required, don't use quotes around them
+        Example of a good response format:
+        {{"key1": "value1", "key2": 42, "key3": false}}
+        """
+            )
 
-    Example of a good response format:
-    {{"key1": "value1", "key2": 42, "key3": false}}
-    """
-        )
+            # Format the schema for the prompt
+            formatted_schema = json.dumps(schema_dict, indent=2)
+            system_content = system_template.format(schema=formatted_schema)
 
-        # Format the schema for the prompt
-        formatted_schema = json.dumps(schema_dict, indent=2)
-        system_content = system_template.format(schema=formatted_schema)
-
-        # Create a function to prepare messages with the system prompt
-        def prepare_messages(input_value: Any) -> List[BaseMessage]:
-            """Prepare messages with system prompt for structured output."""
-            if isinstance(input_value, str):
-                return [
-                    SystemMessage(content=system_content),
-                    HumanMessage(content=input_value),
-                ]
-            elif isinstance(input_value, list):
-                # Check if there's already a system message
-                has_system = any(
-                    getattr(msg, "type", None) == "system" for msg in input_value
-                )
-                if has_system:
-                    # Modify existing system message
-                    messages = input_value.copy()
-                    for i, msg in enumerate(messages):
-                        if getattr(msg, "type", None) == "system":
-                            messages[i] = SystemMessage(
-                                content=f"{msg.content}\n\n{system_content}"
-                            )
-                            break
-                    return messages
-                else:
-                    # Add system message at the beginning
-                    return [SystemMessage(content=system_content)] + input_value  # type: ignore
-            else:
-                # Convert to string and use as human message
-                return [
-                    SystemMessage(content=system_content),
-                    HumanMessage(content=str(input_value)),
-                ]
-
-        # Create a modified version of the model with structured output format
-        structured_model = self.bind(
-            ls_structured_output_format={
-                "schema": schema_dict,
-                "name": schema_name,
-                "method": method,
-                "kwargs": {"method": method, "strict": strict},
-            }
-        )
-
-        # Create the output parser
-        output_parser = StructuredOutputParser()
-
-        # Build the chain
-        if include_raw:
-            # Include raw output in the result
-            def process_with_raw(x: Any) -> Dict[str, Any]:
-                raw_output = structured_model.invoke(prepare_messages(x))
-                try:
-                    if isinstance(raw_output.content, str):
-                        parsed = output_parser.parse(raw_output.content)
+            # Create a function to prepare messages with the system prompt
+            def prepare_messages(input_value: Any) -> List[BaseMessage]:
+                """Prepare messages with system prompt for structured output."""
+                if isinstance(input_value, str):
+                    return [
+                        SystemMessage(content=system_content),
+                        HumanMessage(content=input_value),
+                    ]
+                elif isinstance(input_value, list):
+                    # Check if there's already a system message
+                    has_system = any(
+                        getattr(msg, "type", None) == "system" for msg in input_value
+                    )
+                    if has_system:
+                        # Modify existing system message
+                        messages = input_value.copy()
+                        for i, msg in enumerate(messages):
+                            if getattr(msg, "type", None) == "system":
+                                messages[i] = SystemMessage(
+                                    content=f"{msg.content}\n\n{system_content}"
+                                )
+                                break
+                        return messages
                     else:
-                        parsed = raw_output.content
-                    return {"raw": raw_output, "parsed": parsed, "parsing_error": None}
-                except Exception as e:
-                    return {"raw": raw_output, "parsed": None, "parsing_error": e}
-
-            chain = RunnableLambda(process_with_raw)
-        else:
-            # Only return parsed output
-            def process_without_raw(x: Any) -> Any:
-                raw_output = structured_model.invoke(prepare_messages(x))
-                if isinstance(raw_output.content, str):
-                    return output_parser.parse(raw_output.content)
+                        # Add system message at the beginning
+                        return [SystemMessage(content=system_content)] + input_value  # type: ignore
                 else:
-                    return raw_output.content
+                    # Convert to string and use as human message
+                    return [
+                        SystemMessage(content=system_content),
+                        HumanMessage(content=str(input_value)),
+                    ]
 
-            chain = RunnableLambda(process_without_raw)
+            # Create a modified version of the model with structured output format
+            structured_model = self.bind(
+                ls_structured_output_format={
+                    "schema": schema_dict,
+                    "name": schema_name,
+                    "method": method,
+                    "kwargs": {"method": method, "strict": strict},
+                }
+            )
+
+            # Create the output parser
+            output_parser = StructuredOutputParser()
+
+            # Build the chain
+            if include_raw:
+                # Include raw output in the result
+                def process_with_raw(x: Any) -> Dict[str, Any]:
+                    raw_output = structured_model.invoke(prepare_messages(x))
+                    try:
+                        if isinstance(raw_output.content, str):
+                            parsed = output_parser.parse(raw_output.content)
+                        else:
+                            parsed = raw_output.content
+                        return {
+                            "raw": raw_output,
+                            "parsed": parsed,
+                            "parsing_error": None,
+                        }
+                    except Exception as e:
+                        return {"raw": raw_output, "parsed": None, "parsing_error": e}
+
+                async def aprocess_with_raw(x: Any) -> Dict[str, Any]:
+                    raw_output = await structured_model.ainvoke(prepare_messages(x))
+                    try:
+                        if isinstance(raw_output.content, str):
+                            parsed = output_parser.parse(raw_output.content)
+                        else:
+                            parsed = raw_output.content
+                        return {
+                            "raw": raw_output,
+                            "parsed": parsed,
+                            "parsing_error": None,
+                        }
+                    except Exception as e:
+                        return {"raw": raw_output, "parsed": None, "parsing_error": e}
+
+                chain = RunnableLambda(process_with_raw, afunc=aprocess_with_raw)
+            else:
+                # Only return parsed output
+                def process_without_raw(x: Any) -> Any:
+                    raw_output = structured_model.invoke(prepare_messages(x))
+                    if isinstance(raw_output.content, str):
+                        return output_parser.parse(raw_output.content)
+                    else:
+                        return raw_output.content
+
+                async def aprocess_without_raw(x: Any) -> Any:
+                    raw_output = await structured_model.ainvoke(prepare_messages(x))
+                    if isinstance(raw_output.content, str):
+                        return output_parser.parse(raw_output.content)
+                    else:
+                        return raw_output.content
+
+                chain = RunnableLambda(process_without_raw, afunc=aprocess_without_raw)
+        else:
+            from typing import cast
+
+            from langchain_core.output_parsers import (
+                JsonOutputKeyToolsParser,
+                PydanticToolsParser,
+            )
+            from langchain_core.output_parsers.base import OutputParserLike
+            from langchain_core.runnables import (
+                RunnableMap,
+                RunnablePassthrough,
+            )
+            from langchain_core.utils.function_calling import convert_to_openai_tool
+            from pydantic import BaseModel
+
+            if kwargs:
+                raise ValueError(f"Received unsupported arguments {kwargs}")
+            is_pydantic_schema = isinstance(schema, type) and is_basemodel_subclass(
+                schema
+            )
+            llm = self.bind_tools(
+                [cast(Union[Dict[str, Any], Type[BaseModel]], schema)]
+            )
+
+            if is_pydantic_schema:
+                output_parser: OutputParserLike = PydanticToolsParser(
+                    tools=[schema],  # type: ignore[list-item]
+                    first_tool_only=True,
+                )
+            else:
+                key_name = convert_to_openai_tool(
+                    cast(Union[Dict[str, Any], Type[BaseModel]], schema)
+                )["function"]["name"]
+                output_parser = JsonOutputKeyToolsParser(
+                    key_name=key_name, first_tool_only=True
+                )
+
+            if include_raw:
+                parser_assign = RunnablePassthrough.assign(
+                    parsed=itemgetter("raw") | output_parser,
+                    parsing_error=lambda _: None,
+                )
+                parser_none = RunnablePassthrough.assign(parsed=lambda _: None)
+                parser_with_fallback = parser_assign.with_fallbacks(
+                    [parser_none], exception_key="parsing_error"
+                )
+                return RunnableMap(raw=llm) | parser_with_fallback
+            else:
+                return llm | output_parser
 
         return chain
 
@@ -841,7 +798,7 @@ class ChatQwen(ChatQwQ):
         max_retries: int
             Max number of retries.
         api_key: Optional[str]
-            Qwen QwQ Thingking API key. If not passed in will be read from env var DASHSCOPE_API_KEY.
+            Qwen Qwen3 Thingking API key. If not passed in will be read from env var DASHSCOPE_API_KEY.
 
     See full list of supported init args and their descriptions in the params section.
 


### PR DESCRIPTION
## Key Improvements Proposed
#### Enhancement: Enable Structured JSON Output via response_format for Non-QwQ Models
This change adds support for structured JSON output using the response_format={"type": "json_object"} parameter during model invocation. This ensures that compatible models return valid JSON without additional text, improving interoperability and simplifying downstream parsing.

⚠️ Important Notes: 

QwQ models do not support json_mode or response_format , and attempting to use this feature will result in an error.
Qwen3 models only support structured output when used in non-thinking mode.

### Added support for structured output with Function Calling
Added code to implement structured output using function calling in the with_struct_output function. 

### Remove Some Code
Remove some code, refer to [https://github.com/yigit353/langchain-qwq/issues/10 ](https://github.com/yigit353/langchain-qwq/issues/10). If you think deleting this might cause bugs in tool calls, it can be added back.


