### PR TITLE
Enhance the adaptability of different models

### DIFF
--- a/langchain_qwq/chat_models.py
+++ b/langchain_qwq/chat_models.py
@@ -991,6 +991,8 @@ class ChatQwen(BaseChatOpenAI):
         alias="base_url",
     )
 
+    streaming: bool = Field(default=True)
+
     model_config = ConfigDict(populate_by_name=True)
 
     @property
@@ -1022,6 +1024,18 @@ class ChatQwen(BaseChatOpenAI):
         params = super()._default_params
 
         return params
+
+    def _get_request_payload(
+        self,
+        input_: LanguageModelInput,
+        *,
+        stop: Optional[list[str]] = None,
+        **kwargs: Any,
+    ) -> dict:
+        payload = self._filter_disabled_params(
+            **super()._get_request_payload(input_, stop=stop, **kwargs)
+        )
+        return payload
 
     @model_validator(mode="after")
     def validate_environment(self) -> Self:
@@ -1158,7 +1172,6 @@ class ChatQwen(BaseChatOpenAI):
         run_manager: Optional[CallbackManagerForLLMRun] = None,
         **kwargs: Any,
     ) -> ChatResult:
-        self.streaming = True
         try:
             return super()._generate(
                 messages, stop=stop, run_manager=run_manager, **kwargs
@@ -1178,7 +1191,6 @@ class ChatQwen(BaseChatOpenAI):
         run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
         **kwargs: Any,
     ) -> ChatResult:
-        self.streaming = True
         try:
             return await super()._agenerate(
                 messages, stop=stop, run_manager=run_manager, **kwargs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "langchain-qwq"
-version = "0.1.5"
+version = "0.1.6"
 description = "An integration package connecting Qwen 3, QwQ and LangChain"
 authors = ["Yiğit Bekir Kaya, PhD <yigit353@gmail.com>"]
 readme = "README.md"

--- a/tests/integration_tests/test_chat_models.py
+++ b/tests/integration_tests/test_chat_models.py
@@ -40,7 +40,7 @@ class TestChatQwenIntegration(ChatModelIntegrationTests):
     def chat_model_params(self) -> dict:
         # These should be parameters used to initialize your integration for testing
         return {
-            "model": "qwen-plus-latest",
+            "model": "qwen3-235b-a22b",
         }
 
     @property


### PR DESCRIPTION
Fixed the issue where an error occurred during the integration of langmem and chatQwen due to the Qwen3 model itself not supporting forced tool calls. Set the streaming parameter to true to resolve the problem of Qwen3's reasoning mode on Alibaba Cloud not supporting streaming calls, and allow users to set the parameter to false to ensure they can use non-streaming calls when supported.