### PR TITLE
fix pr issue and add context cache middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,33 @@ model = ChatQwen(model="qwen3-vl-plus")
 print(model.invoke(messages))
 ```
 
+## Middleware
+
+This library provides a middleware `DashScopeContextCacheMiddleware` that can be used to create display caching. 
+
+Example usage
+
+```python
+from langchain.agents import create_agent
+from langchain.tools import tool
+
+from langchain_qwq import ChatQwen
+from langchain_qwq.middleware import DashScopeContextCacheMiddleware
+
+
+@tool
+def get_weather(city: str) -> str:
+    """Get the current weather in a given city."""
+    return f"The weather in {city} is 20 degrees Celsius."
+
+
+model = ChatQwen(model="qwen3-max")
+
+agent = create_agent(
+    model, tools=[get_weather], middleware=[DashScopeContextCacheMiddleware()]
+)
+```
+
 ## Model Comparison
 
 | Feature           | ChatQwQ    | ChatQwen        |

--- a/langchain_qwq/chat_models.py
+++ b/langchain_qwq/chat_models.py
@@ -10,7 +10,6 @@ from typing import (
     Literal,
     Optional,
     Type,
-    cast,
 )
 
 import json_repair as json
@@ -19,8 +18,8 @@ from langchain_core.callbacks import (
     CallbackManagerForLLMRun,
 )
 from langchain_core.language_models import LanguageModelInput
-from langchain_core.messages import AIMessageChunk, BaseMessage, ToolCall
-from langchain_core.outputs import ChatGenerationChunk, ChatResult
+from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage, ToolCall
+from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 from langchain_core.runnables import Runnable
 from pydantic import (
     Field,
@@ -169,11 +168,10 @@ class ChatQwQ(_BaseChatQwen):
 
                     # Handle tool calls
                     if tool_calls := delta.get("tool_calls"):
-                        generation_chunk.message.tool_call_chunks = []
+                        generation_chunk.message.tool_calls = []
                         for tool_call in tool_calls:
-                            generation_chunk.message.tool_call_chunks.append(
+                            generation_chunk.message.tool_calls.append(
                                 {
-                                    "index": tool_call.get("index"),
                                     "id": tool_call.get("id", ""),
                                     "type": "function",  # type: ignore
                                     "name": tool_call.get("function", {}).get(
@@ -243,20 +241,6 @@ class ChatQwQ(_BaseChatQwen):
                         ):
                             result.tool_calls.append(tc)
 
-            # Clear invalid_tool_calls if we have valid tool_calls for the same ID
-            if (
-                hasattr(result, "tool_calls")
-                and result.tool_calls
-                and hasattr(result, "invalid_tool_calls")
-                and result.invalid_tool_calls
-            ):
-                valid_ids = {tc.get("id") for tc in result.tool_calls if tc.get("id")}
-                result.invalid_tool_calls = [
-                    tc
-                    for tc in result.invalid_tool_calls
-                    if tc.get("id") not in valid_ids
-                ]
-
             return result
 
         # Monkey patch the __add__ method
@@ -264,68 +248,195 @@ class ChatQwQ(_BaseChatQwen):
 
         try:
             kwargs["stream_options"] = {"include_usage": True}
-
-            # Track tool call chunks to reconstruct tool calls at the end
-            accumulated_tool_call_chunks: Dict[int, Dict[str, Any]] = {}
-
             # Original streaming
             for chunk in super()._stream(
                 messages, stop=stop, run_manager=run_manager, **kwargs
             ):
-                # Accumulate tool call chunks
-                if (
-                    isinstance(chunk.message, AIMessageChunk)
-                    and chunk.message.tool_call_chunks
-                ):
-                    for tc_chunk in chunk.message.tool_call_chunks:
-                        index = tc_chunk.get("index")
-                        if index is not None:
-                            if index not in accumulated_tool_call_chunks:
-                                accumulated_tool_call_chunks[index] = {
-                                    "index": index,
-                                    "id": tc_chunk.get("id", ""),
-                                    "name": tc_chunk.get("name", ""),
-                                    "args": tc_chunk.get("args", "") or "",
-                                    "type": "tool_call",
-                                }
-                            else:
-                                if tc_chunk.get("id"):
-                                    accumulated_tool_call_chunks[index]["id"] = (
-                                        tc_chunk.get("id")
-                                    )
-                                if tc_chunk.get("name"):
-                                    accumulated_tool_call_chunks[index]["name"] = (
-                                        tc_chunk.get("name")
-                                    )
-                                if tc_chunk.get("args"):
-                                    accumulated_tool_call_chunks[index]["args"] += (
-                                        tc_chunk.get("args") or ""
-                                    )
-
                 yield chunk
+        finally:
+            # Restore the original method
+            AIMessageChunk.__add__ = original_add  # type: ignore
 
-            # Yield final chunk with parsed tool calls if any
-            if accumulated_tool_call_chunks:
-                tool_calls: List[ToolCall] = []
-                for index in sorted(accumulated_tool_call_chunks.keys()):
-                    tc = accumulated_tool_call_chunks[index]
-                    try:
-                        args = json.loads(str(tc["args"]))
-                        tool_calls.append(
-                            {
-                                "name": str(tc["name"]),
-                                "args": cast(Dict[str, Any], args),
-                                "id": str(tc["id"]),
-                                "type": "tool_call",
+    def _generate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        try:
+            chunks = list(
+                self._stream(messages, stop=stop, run_manager=run_manager, **kwargs)
+            )
+            content = ""
+            reasoning_content = ""
+            tool_calls = []
+            current_tool_calls = {}  # Track tool calls being built
+
+            for chunk in chunks:
+                if isinstance(chunk.message.content, str):
+                    content += chunk.message.content
+                reasoning_content += chunk.message.additional_kwargs.get(
+                    "reasoning_content", ""
+                )
+
+                if chunk_tool_calls := chunk.message.additional_kwargs.get(
+                    "tool_calls", []
+                ):
+                    for tool_call in chunk_tool_calls:
+                        index = tool_call.get("index", "")
+
+                        # Initialize tool call entry if needed
+                        if index not in current_tool_calls:
+                            current_tool_calls[index] = {
+                                "id": "",
+                                "name": "",
+                                "args": "",
+                                "type": "function",
                             }
-                        )
-                    except Exception:
-                        pass
 
-                if tool_calls:
-                    yield ChatGenerationChunk(
-                        message=AIMessageChunk(content="", tool_calls=tool_calls)
+                        # Update tool call ID
+                        if tool_id := tool_call.get("id"):
+                            current_tool_calls[index]["id"] = tool_id
+
+                        # Update function name and arguments
+                        if function := tool_call.get("function"):
+                            if name := function.get("name"):
+                                current_tool_calls[index]["name"] = name
+                            if args := function.get("arguments"):
+                                current_tool_calls[index]["args"] += args
+
+            # Convert accumulated tool calls to final format
+            tool_calls = list(current_tool_calls.values())
+            for tool_call in tool_calls:
+                tool_call["args"] = json.loads(tool_call["args"])  # type: ignore
+
+            last_chunk = chunks[-1]
+
+            # Extract usage info from the last chunk's generation_info
+            generation_info = last_chunk.generation_info or {}
+            # Extract usage metadata from chunk if available
+            if hasattr(last_chunk.message, "usage_metadata"):
+                usage_metadata = last_chunk.message.usage_metadata  # type: ignore
+            else:
+                usage_metadata = {}
+
+            return ChatResult(
+                generations=[
+                    ChatGeneration(
+                        generation_info=generation_info,
+                        message=AIMessage(
+                            content=content,
+                            additional_kwargs={"reasoning_content": reasoning_content},
+                            tool_calls=tool_calls,
+                            usage_metadata=usage_metadata,
+                            response_metadata={"model_name": self.model_name},
+                        ),
                     )
+                ],
+                # Explicitly include usage at the ChatResult level if needed
+                llm_output=(
+                    {"usage": generation_info.get("usage")}
+                    if "usage" in generation_info
+                    else None
+                ),
+            )
+
+        except JSONDecodeError as e:
+            raise JSONDecodeError(
+                "Qwen QwQ Thingking API returned an invalid response. "
+                "Please check the API status and try again.",
+                e.doc,
+                e.pos,
+            ) from e
+
+    async def _agenerate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        try:
+            chunks = [
+                chunk
+                async for chunk in self._astream(
+                    messages, stop=stop, run_manager=run_manager, **kwargs
+                )
+            ]
+            content = ""
+            reasoning_content = ""
+            tool_calls = []
+            current_tool_calls = {}  # Track tool calls being built
+
+            for chunk in chunks:
+                if isinstance(chunk.message.content, str):
+                    content += chunk.message.content
+                reasoning_content += chunk.message.additional_kwargs.get(
+                    "reasoning_content", ""
+                )
+
+                if chunk_tool_calls := chunk.message.additional_kwargs.get(
+                    "tool_calls", []
+                ):
+                    for tool_call in chunk_tool_calls:
+                        index = tool_call.get("index", "")
+
+                        # Initialize tool call entry if needed
+                        if index not in current_tool_calls:
+                            current_tool_calls[index] = {
+                                "id": "",
+                                "name": "",
+                                "args": "",
+                                "type": "function",
+                            }
+
+                        # Update tool call ID
+                        if tool_id := tool_call.get("id"):
+                            current_tool_calls[index]["id"] = tool_id
+
+                        # Update function name and arguments
+                        if function := tool_call.get("function"):
+                            if name := function.get("name"):
+                                current_tool_calls[index]["name"] = name
+                            if args := function.get("arguments"):
+                                current_tool_calls[index]["args"] += args
+
+            # Convert accumulated tool calls to final format
+            tool_calls = list(current_tool_calls.values())
+            for tool_call in tool_calls:
+                tool_call["args"] = json.loads(tool_call["args"])  # type: ignore
+
+            last_chunk = chunks[-1]
+
+            # Extract usage info from the last chunk's generation_info
+            generation_info = last_chunk.generation_info or {}
+            # Extract usage metadata from chunk if available
+            if hasattr(last_chunk.message, "usage_metadata"):
+                usage_metadata = last_chunk.message.usage_metadata  # type: ignore
+            else:
+                usage_metadata = {}
+
+            return ChatResult(
+                generations=[
+                    ChatGeneration(
+                        generation_info=generation_info,
+                        message=AIMessage(
+                            content=content,
+                            additional_kwargs={"reasoning_content": reasoning_content},
+                            tool_calls=tool_calls,
+                            usage_metadata=usage_metadata,
+                            response_metadata={"model_name": self.model_name},
+                        ),
+                    )
+                ],
+                # Explicitly include usage at the ChatResult level if needed
+                llm_output=(
+                    {"usage": generation_info.get("usage")}
+                    if "usage" in generation_info
+                    else None
+                ),
+            )
 
         except JSONDecodeError as e:
             raise JSONDecodeError(
@@ -391,20 +502,6 @@ class ChatQwQ(_BaseChatQwen):
                         ):
                             result.tool_calls.append(tc)
 
-            # Clear invalid_tool_calls if we have valid tool_calls for the same ID
-            if (
-                hasattr(result, "tool_calls")
-                and result.tool_calls
-                and hasattr(result, "invalid_tool_calls")
-                and result.invalid_tool_calls
-            ):
-                valid_ids = {tc.get("id") for tc in result.tool_calls if tc.get("id")}
-                result.invalid_tool_calls = [
-                    tc
-                    for tc in result.invalid_tool_calls
-                    if tc.get("id") not in valid_ids
-                ]
-
             return result
 
         # Monkey patch the __add__ method
@@ -412,69 +509,11 @@ class ChatQwQ(_BaseChatQwen):
 
         try:
             kwargs["stream_options"] = {"include_usage": True}
-
-            # Track tool call chunks to reconstruct tool calls at the end
-            accumulated_tool_call_chunks: Dict[int, Dict[str, Any]] = {}
-
             # Original async streaming
             async for chunk in super()._astream(
                 messages, stop=stop, run_manager=run_manager, **kwargs
             ):
-                # Accumulate tool call chunks
-                if (
-                    isinstance(chunk.message, AIMessageChunk)
-                    and chunk.message.tool_call_chunks
-                ):
-                    for tc_chunk in chunk.message.tool_call_chunks:
-                        index = tc_chunk.get("index")
-                        if index is not None:
-                            if index not in accumulated_tool_call_chunks:
-                                accumulated_tool_call_chunks[index] = {
-                                    "index": index,
-                                    "id": tc_chunk.get("id", ""),
-                                    "name": tc_chunk.get("name", ""),
-                                    "args": tc_chunk.get("args", "") or "",
-                                    "type": "tool_call",
-                                }
-                            else:
-                                if tc_chunk.get("id"):
-                                    accumulated_tool_call_chunks[index]["id"] = (
-                                        tc_chunk.get("id")
-                                    )
-                                if tc_chunk.get("name"):
-                                    accumulated_tool_call_chunks[index]["name"] = (
-                                        tc_chunk.get("name")
-                                    )
-                                if tc_chunk.get("args"):
-                                    accumulated_tool_call_chunks[index]["args"] += (
-                                        tc_chunk.get("args") or ""
-                                    )
-
                 yield chunk
-
-            # Yield final chunk with parsed tool calls if any
-            if accumulated_tool_call_chunks:
-                tool_calls: List[ToolCall] = []
-                for index in sorted(accumulated_tool_call_chunks.keys()):
-                    tc = accumulated_tool_call_chunks[index]
-                    try:
-                        args = json.loads(str(tc["args"]))
-                        tool_calls.append(
-                            {
-                                "name": str(tc["name"]),
-                                "args": cast(Dict[str, Any], args),
-                                "id": str(tc["id"]),
-                                "type": "tool_call",
-                            }
-                        )
-                    except Exception:
-                        pass
-
-                if tool_calls:
-                    yield ChatGenerationChunk(
-                        message=AIMessageChunk(content="", tool_calls=tool_calls)
-                    )
-
         finally:
             # Restore the original method
             AIMessageChunk.__add__ = original_add  # type: ignore

--- a/langchain_qwq/middleware/__init__.py
+++ b/langchain_qwq/middleware/__init__.py
@@ -1,0 +1,5 @@
+from .context_cache import DashScopeContextCacheMiddleware
+
+__all__ = [
+    "DashScopeContextCacheMiddleware",
+]

--- a/langchain_qwq/middleware/context_cache.py
+++ b/langchain_qwq/middleware/context_cache.py
@@ -1,0 +1,64 @@
+from typing import Awaitable, Callable
+
+from langchain.agents.middleware import AgentMiddleware, ModelRequest, ModelResponse
+from langchain.agents.middleware.types import ModelCallResult
+
+
+class DashScopeContextCacheMiddleware(AgentMiddleware):
+    """Middleware for caching context in DashScope API.please refer to https://help.aliyun.com/zh/model-studio/context-cache for more details.
+
+    Example:
+        ```python
+        from langchain_qwq.middleware import DashScopeContextCacheMiddleware
+        ```
+    """
+
+    def wrap_model_call(
+        self, request: ModelRequest, handler: Callable[[ModelRequest], ModelResponse]
+    ) -> ModelCallResult:
+        messages = request.state.get("messages", [])
+        message = messages[-1]
+
+        request = request.override(
+            messages=[
+                *messages[:-1],
+                message.model_copy(
+                    update={
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": message.content,
+                                "cache_control": {"type": "ephemeral"},
+                            }
+                        ]
+                    }
+                ),
+            ]
+        )
+        return handler(request)
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelCallResult:
+        messages = request.state.get("messages", [])
+        message = messages[-1]
+
+        request = request.override(
+            messages=[
+                *messages[:-1],
+                message.model_copy(
+                    update={
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": message.content,
+                                "cache_control": {"type": "ephemeral"},
+                            }
+                        ]
+                    }
+                ),
+            ]
+        )
+        return await handler(request)


### PR DESCRIPTION
This PR fixes a #31  that caused **duplicate tool calls** to appear in the output when using `ChatQwQ`.

For example, before this fix:

```python
from langchain_qwq import ChatQwQ
from langchain.tools import tool

@tool
def get_weather(city: str) -> str:
    """Get the current weather in a given city."""
    return f"The weather in {city} is 20 degrees Celsius."

model = ChatQwQ(model="qwq-plus").bind_tools([get_weather])
response = model.invoke("what is the weather in New York?")
print(response.tool_calls)
```

Would incorrectly output **two identical tool calls**:

```python
[
  {'name': 'get_weather', 'args': {'city': 'New York'}, 'id': 'call_0308bce2dbc546f9ad409a', 'type': 'tool_call'},
  {'name': 'get_weather', 'args': {'city': 'New York'}, 'id': 'call_0308bce2dbc546f9ad409a', 'type': 'tool_call'}
]
```

This happened because PR #31’s streaming logic.This PR corrects the behavior:

```python
[{'name': 'get_weather', 'args': {'city': 'New York'}, 'id': 'call_1131d0e5b2e9425d9ce8d5', 'type': 'tool_call'}]
```

Additionally:
- Adds middleware support for explicit caching with DashScope.
- All tests pass.

This change ensures compatibility with LangChain’s expected tool-calling interface and prevents downstream errors caused by duplicated or malformed tool calls.
```
============================= slowest 5 durations =============================
93.91s call     tests/unit_tests/test_chat_models.py::TestChatQwQUnit::test_init_time
26.85s call     tests/integration_tests/test_chat_models.py::TestChatQwQIntegration::test_usage_metadata_streaming
22.13s call     tests/integration_tests/test_chat_models.py::TestChatQwQIntegration::test_structured_output_pydantic_2_v1
18.98s call     tests/integration_tests/test_chat_models.py::TestChatQwQIntegration::test_structured_output_optional_param
12.98s call     tests/integration_tests/test_chat_models.py::TestChatQwQIntegration::test_unicode_tool_call_integration
=========== 74 passed, 19 skipped, 18 warnings in 480.89s (0:08:00) ===========
Finished running tests!
```