### PR TITLE
Bump urllib3 to >=2.7.0 (security fix)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2444,14 +2444,14 @@ typing-extensions = ">=4.12.0"
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main", "test"]
 files = [
-    {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
-    {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]
@@ -3114,4 +3114,4 @@ typing = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "9bfacbcbb6843c3129245e82cc79c34cb6bc53709b6cdba83b03fac0c0789391"
+content-hash = "4faf129c64982ac91495fb9c399b1728bd63f3f4ca15fa8c2c58a9f9f175c6c0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ langchain = "^1.0.5"
 langchain-core = ">=1.2.5"  # CVE fix: serialization injection vulnerability
 langchain-openai = "^1.0.2"
 json-repair = "^0.53.0"
-urllib3 = ">=2.6.0"  # Security fix: CVE-2024-XXXXX (streaming API, decompression chain, redirect issues)
+urllib3 = ">=2.7.0"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "T201"]


### PR DESCRIPTION
Require urllib3 >=2.7.0 in pyproject.toml to address security issues and regenerate poetry.lock so the lockfile pins the updated urllib3 release. This updates the project dependency to the patched version.