### PR TITLE
Bump langchain-core to 1.4.0; add langchain-protocol

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -602,20 +602,21 @@ xai = ["langchain-xai"]
 
 [[package]]
 name = "langchain-core"
-version = "1.2.6"
+version = "1.4.0"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = "<4.0.0,>=3.10.0"
 groups = ["main", "test"]
 files = [
-    {file = "langchain_core-1.2.6-py3-none-any.whl", hash = "sha256:aa6ed954b4b1f4504937fe75fdf674317027e9a91ba7a97558b0de3dc8004e34"},
-    {file = "langchain_core-1.2.6.tar.gz", hash = "sha256:b4e7841dd7f8690375aa07c54739178dc2c635147d475e0c2955bf82a1afa498"},
+    {file = "langchain_core-1.4.0-py3-none-any.whl", hash = "sha256:23cbbdb46e38ddd1dd5247e6167e96013eae74bea4c5949c550809970a9e565c"},
+    {file = "langchain_core-1.4.0.tar.gz", hash = "sha256:1dc341eed802ed9c117c0df3923c991e5e9e226571e5725c194eeb5bd93d1a7f"},
 ]
 
 [package.dependencies]
 jsonpatch = ">=1.33.0,<2.0.0"
+langchain-protocol = ">=0.0.14"
 langsmith = ">=0.3.45,<1.0.0"
-packaging = ">=23.2.0,<26.0.0"
+packaging = ">=23.2.0"
 pydantic = ">=2.7.4,<3.0.0"
 pyyaml = ">=5.3.0,<7.0.0"
 tenacity = ">=8.1.0,<8.4.0 || >8.4.0,<10.0.0"
@@ -638,6 +639,21 @@ files = [
 langchain-core = ">=1.0.2,<2.0.0"
 openai = ">=1.109.1,<3.0.0"
 tiktoken = ">=0.7.0,<1.0.0"
+
+[[package]]
+name = "langchain-protocol"
+version = "0.0.15"
+description = "Python bindings for the LangChain agent streaming protocol"
+optional = false
+python-versions = "<4.0.0,>=3.10.0"
+groups = ["main", "test"]
+files = [
+    {file = "langchain_protocol-0.0.15-py3-none-any.whl", hash = "sha256:461eb794358f83d5e42635a5797799ffec7b4702314e34edf73ac21e75d3ef79"},
+    {file = "langchain_protocol-0.0.15.tar.gz", hash = "sha256:9ab2d11ee73944754f10e037e717098d3a6796f0e58afa9cadda6154e7655ade"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.7.0,<5.0.0"
 
 [[package]]
 name = "langchain-tests"
@@ -3114,4 +3130,4 @@ typing = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "4faf129c64982ac91495fb9c399b1728bd63f3f4ca15fa8c2c58a9f9f175c6c0"
+content-hash = "1ef5df5d5a07524eb7f3f732971a1795a15454c4b4ca9ce8654d64252633f82a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ disallow_untyped_defs = true
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
 langchain = "^1.0.5"
-langchain-core = ">=1.2.5"  # CVE fix: serialization injection vulnerability
+langchain-core = ">=1.4.0"
 langchain-openai = "^1.0.2"
 json-repair = "^0.53.0"
 urllib3 = ">=2.7.0"


### PR DESCRIPTION
Update dependencies to pull in langchain-core 1.4.0 (replacing 1.2.6) in pyproject.toml and poetry.lock to include fixes (including the referenced CVE fix). Add the langchain-protocol 0.0.15 package and dependency, relax the packaging upper bound in the lockfile, and update package file hashes and the lockfile content-hash.