### PR TITLE
Security: bump 7 transitive/direct dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -735,14 +735,14 @@ xxhash = ">=3.5.0"
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "3.0.1"
+version = "4.1.0"
 description = "Library with base interfaces for LangGraph checkpoint savers."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "langgraph_checkpoint-3.0.1-py3-none-any.whl", hash = "sha256:9b04a8d0edc0474ce4eaf30c5d731cee38f11ddff50a6177eead95b5c4e4220b"},
-    {file = "langgraph_checkpoint-3.0.1.tar.gz", hash = "sha256:59222f875f85186a22c494aedc65c4e985a3df27e696e5016ba0b98a5ed2cee0"},
+    {file = "langgraph_checkpoint-4.1.0-py3-none-any.whl", hash = "sha256:8bc2a0466a20c38b865ce6671b42093fd5c041133f32351cae4222e0eeaf7fb5"},
+    {file = "langgraph_checkpoint-4.1.0.tar.gz", hash = "sha256:e5bb304e30fc1363ac8fcb5f7dee5ca2185d77fe475b0d01de2c5f91324c2c21"},
 ]
 
 [package.dependencies]
@@ -3121,4 +3121,4 @@ typing = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "024f500c43ae8996d4f347c859af3fd83741c7a13d3aa9bc7abc5e5702c1a9cd"
+content-hash = "4af8e116f658d5036a9e43da4946e8c87b3a2164e7aaadebb063a639924fbe5c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -715,21 +715,21 @@ vcrpy = ">=7.0.0,<8.0.0"
 
 [[package]]
 name = "langgraph"
-version = "1.0.2"
+version = "1.0.10"
 description = "Building stateful, multi-actor applications with LLMs"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "langgraph-1.0.2-py3-none-any.whl", hash = "sha256:b3d56b8c01de857b5fb1da107e8eab6e30512a377685eeedb4f76456724c9729"},
-    {file = "langgraph-1.0.2.tar.gz", hash = "sha256:dae1af08d6025cb1fcaed68f502c01af7d634d9044787c853a46c791cfc52f67"},
+    {file = "langgraph-1.0.10-py3-none-any.whl", hash = "sha256:7c298bef4f6ea292fcf9824d6088fe41a6727e2904ad6066f240c4095af12247"},
+    {file = "langgraph-1.0.10.tar.gz", hash = "sha256:73bd10ee14a8020f31ef07e9cd4c1a70c35cc07b9c2b9cd637509a10d9d51e29"},
 ]
 
 [package.dependencies]
 langchain-core = ">=0.1"
-langgraph-checkpoint = ">=2.1.0,<4.0.0"
-langgraph-prebuilt = ">=1.0.2,<1.1.0"
-langgraph-sdk = ">=0.2.2,<0.3.0"
+langgraph-checkpoint = ">=2.1.0,<5.0.0"
+langgraph-prebuilt = ">=1.0.8,<1.1.0"
+langgraph-sdk = ">=0.3.0,<0.4.0"
 pydantic = ">=2.7.4"
 xxhash = ">=3.5.0"
 
@@ -751,35 +751,35 @@ ormsgpack = ">=1.12.0"
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "1.0.2"
+version = "1.0.13"
 description = "Library with high-level APIs for creating and executing LangGraph agents and tools."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "langgraph_prebuilt-1.0.2-py3-none-any.whl", hash = "sha256:d9499f7c449fb637ee7b87e3f6a3b74095f4202053c74d33894bd839ea4c57c7"},
-    {file = "langgraph_prebuilt-1.0.2.tar.gz", hash = "sha256:9896dbabf04f086eb59df4294f54ab5bdb21cd78e27e0a10e695dffd1cc6097d"},
+    {file = "langgraph_prebuilt-1.0.13-py3-none-any.whl", hash = "sha256:7055e9fad41fbd3593800aed0aea0a6e974b17f33ed51b80d3d3a031212dd7c0"},
+    {file = "langgraph_prebuilt-1.0.13.tar.gz", hash = "sha256:ad219782a80e1718e7e7794de49e0ae307111d45cbcffab9a52725a66a609456"},
 ]
 
 [package.dependencies]
-langchain-core = ">=1.0.0"
-langgraph-checkpoint = ">=2.1.0,<4.0.0"
+langchain-core = ">=1.3.1"
+langgraph-checkpoint = ">=2.1.0,<5.0.0"
 
 [[package]]
 name = "langgraph-sdk"
-version = "0.2.9"
+version = "0.3.14"
 description = "SDK for interacting with LangGraph API"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "langgraph_sdk-0.2.9-py3-none-any.whl", hash = "sha256:fbf302edadbf0fb343596f91c597794e936ef68eebc0d3e1d358b6f9f72a1429"},
-    {file = "langgraph_sdk-0.2.9.tar.gz", hash = "sha256:b3bd04c6be4fa382996cd2be8fbc1e7cc94857d2bc6b6f4599a7f2a245975303"},
+    {file = "langgraph_sdk-0.3.14-py3-none-any.whl", hash = "sha256:68935bf6f4924eda92617a9e5dfb4f4281197508c648cb9d62ff083907607f9d"},
+    {file = "langgraph_sdk-0.3.14.tar.gz", hash = "sha256:acd1674c538e97f3cdaa610f6dd7e34bc9bad30167f0ccc482dcd563325e81f5"},
 ]
 
 [package.dependencies]
 httpx = ">=0.25.2"
-orjson = ">=3.10.1"
+orjson = ">=3.11.5"
 
 [[package]]
 name = "langsmith"
@@ -3121,4 +3121,4 @@ typing = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "515f48c454941c592a55ffe2177a4a46b65c6e22ef5963d27d8f617aeb0a9945"
+content-hash = "024f500c43ae8996d4f347c859af3fd83741c7a13d3aa9bc7abc5e5702c1a9cd"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2142,25 +2142,25 @@ files = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.34.2"
 description = "Python HTTP for Humans."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main", "test"]
 files = [
-    {file = "requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"},
-    {file = "requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"},
+    {file = "requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"},
+    {file = "requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed"},
 ]
 
 [package.dependencies]
-certifi = ">=2017.4.17"
+certifi = ">=2023.5.7"
 charset_normalizer = ">=2,<4"
 idna = ">=2.5,<4"
-urllib3 = ">=1.21.1,<3"
+urllib3 = ">=1.26,<3"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<8)"]
 
 [[package]]
 name = "requests-toolbelt"
@@ -3116,4 +3116,4 @@ typing = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "3fb4a59568a6ee1cad78a8bafabc45db2730073b74817d9f652c07986d00de3c"
+content-hash = "66f1de41f33cf7780e18c2a199d922bac7cbcdd13479f97c4108e61c36e3207d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1756,14 +1756,14 @@ typing-extensions = ">=4.14.1"
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
-python-versions = ">=3.8"
-groups = ["test"]
+python-versions = ">=3.9"
+groups = ["main", "test"]
 files = [
-    {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
-    {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
 ]
 
 [package.extras]
@@ -3116,4 +3116,4 @@ typing = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "c668a5ca758e1c3b9c38290a1bc2d4300a28dcc296db0b471fbb7c35a17376e0"
+content-hash = "95e7271ca34faab49acda5670e0b01a2603139ec399b135288c210064027d0fd"

--- a/poetry.lock
+++ b/poetry.lock
@@ -625,19 +625,19 @@ uuid-utils = ">=0.12.0,<1.0"
 
 [[package]]
 name = "langchain-openai"
-version = "1.0.2"
+version = "1.2.1"
 description = "An integration package connecting OpenAI and LangChain"
 optional = false
 python-versions = "<4.0.0,>=3.10.0"
 groups = ["main"]
 files = [
-    {file = "langchain_openai-1.0.2-py3-none-any.whl", hash = "sha256:b3eb9b82752063b46452aa868d8c8bc1604e57631648c3bc325bba58d3aeb143"},
-    {file = "langchain_openai-1.0.2.tar.gz", hash = "sha256:621e8295c52db9a1fc74806a0bd227ea215c132c6c5e421d2982c9ee78468769"},
+    {file = "langchain_openai-1.2.1-py3-none-any.whl", hash = "sha256:a80732185030d4f453dda6c25feef46f645f665423fdffe38ae3edf1ac3c6c4d"},
+    {file = "langchain_openai-1.2.1.tar.gz", hash = "sha256:ee4480b787706361b7125fad46930589a624df87aa158c6986ef1fad10d10675"},
 ]
 
 [package.dependencies]
-langchain-core = ">=1.0.2,<2.0.0"
-openai = ">=1.109.1,<3.0.0"
+langchain-core = ">=1.3.2,<2.0.0"
+openai = ">=2.26.0,<3.0.0"
 tiktoken = ">=0.7.0,<1.0.0"
 
 [[package]]
@@ -1237,14 +1237,14 @@ files = [
 
 [[package]]
 name = "openai"
-version = "2.7.1"
+version = "2.37.0"
 description = "The official Python library for the openai API"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "openai-2.7.1-py3-none-any.whl", hash = "sha256:2f2530354d94c59c614645a4662b9dab0a5b881c5cd767a8587398feac0c9021"},
-    {file = "openai-2.7.1.tar.gz", hash = "sha256:df4d4a3622b2df3475ead8eb0fbb3c27fd1c070fa2e55d778ca4f40e0186c726"},
+    {file = "openai-2.37.0-py3-none-any.whl", hash = "sha256:814633888b8f3b1ffd6615697c6e4ef93632d08b7c2e28c8c5ef3556e5a10107"},
+    {file = "openai-2.37.0.tar.gz", hash = "sha256:f4bc562cc5f3a43d40d678105572d9d44765f6e0f50c125f63055419b72f4bd9"},
 ]
 
 [package.dependencies]
@@ -1255,7 +1255,7 @@ jiter = ">=0.10.0,<1"
 pydantic = ">=1.9.0,<3"
 sniffio = "*"
 tqdm = ">4"
-typing-extensions = ">=4.11,<5"
+typing-extensions = ">=4.14,<5"
 
 [package.extras]
 aiohttp = ["aiohttp", "httpx-aiohttp (>=0.1.9)"]
@@ -3121,4 +3121,4 @@ typing = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "7f9cfcc7308f43cde0ff40192a9fbfd3c29e90d15305a081e8cd68db196398df"
+content-hash = "515f48c454941c592a55ffe2177a4a46b65c6e22ef5963d27d8f617aeb0a9945"

--- a/poetry.lock
+++ b/poetry.lock
@@ -783,31 +783,36 @@ orjson = ">=3.10.1"
 
 [[package]]
 name = "langsmith"
-version = "0.4.41"
+version = "0.8.5"
 description = "Client library to connect to the LangSmith Observability and Evaluation Platform."
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "test"]
 files = [
-    {file = "langsmith-0.4.41-py3-none-any.whl", hash = "sha256:5cdc554e5f0361bf791fdd5e8dea16d5ba9dfce09b3b8f8bba5e99450c569b27"},
-    {file = "langsmith-0.4.41.tar.gz", hash = "sha256:b88d03bb157cf69d1afee250a658d847003babbbd9647f720edcc9b03a0857cd"},
+    {file = "langsmith-0.8.5-py3-none-any.whl", hash = "sha256:efc779f9d450dcaf9d97bc8894f4926276509d6e730e05289af9a64debce06ae"},
+    {file = "langsmith-0.8.5.tar.gz", hash = "sha256:3615243d99c12f4047f13042bdc05a373dce232d106a6511b3ca7b48c5af1c2c"},
 ]
 
 [package.dependencies]
 httpx = ">=0.23.0,<1"
 orjson = {version = ">=3.9.14", markers = "platform_python_implementation != \"PyPy\""}
 packaging = ">=23.2"
-pydantic = ">=1,<3"
+pydantic = ">=2,<3"
 requests = ">=2.0.0"
 requests-toolbelt = ">=1.0.0"
+uuid-utils = ">=0.12.0,<1.0"
+xxhash = ">=3.0.0"
 zstandard = ">=0.23.0"
 
 [package.extras]
 claude-agent-sdk = ["claude-agent-sdk (>=0.1.0)"]
+google-adk = ["google-adk (>=1.0.0)", "wrapt (>=1.16.0)"]
 langsmith-pyo3 = ["langsmith-pyo3 (>=0.1.0rc2)"]
 openai-agents = ["openai-agents (>=0.0.3)"]
 otel = ["opentelemetry-api (>=1.30.0)", "opentelemetry-exporter-otlp-proto-http (>=1.30.0)", "opentelemetry-sdk (>=1.30.0)"]
 pytest = ["pytest (>=7.0.0)", "rich (>=13.9.4)", "vcrpy (>=7.0.0)"]
+sandbox = ["websockets (>=15.0)"]
+strands-agents = ["opentelemetry-api (>=1.30.0)", "opentelemetry-exporter-otlp-proto-http (>=1.30.0)", "opentelemetry-sdk (>=1.30.0)", "strands-agents (>=0.1.0)", "strands-agents-tools (>=0.2.0)"]
 vcr = ["vcrpy (>=7.0.0)"]
 
 [[package]]
@@ -2705,7 +2710,7 @@ version = "3.6.0"
 description = "Python binding for xxHash"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "xxhash-3.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:87ff03d7e35c61435976554477a7f4cd1704c3596a89a8300d5ce7fc83874a71"},
     {file = "xxhash-3.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f572dfd3d0e2eb1a57511831cf6341242f5a9f8298a45862d085f5b93394a27d"},
@@ -3116,4 +3121,4 @@ typing = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "66f1de41f33cf7780e18c2a199d922bac7cbcdd13479f97c4108e61c36e3207d"
+content-hash = "7f9cfcc7308f43cde0ff40192a9fbfd3c29e90d15305a081e8cd68db196398df"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1919,14 +1919,14 @@ watchdog = ">=2.0.0"
 
 [[package]]
 name = "python-dotenv"
-version = "1.2.1"
+version = "1.2.2"
 description = "Read key-value pairs from a .env file and set them as environment variables"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev", "test"]
 files = [
-    {file = "python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61"},
-    {file = "python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6"},
+    {file = "python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a"},
+    {file = "python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3"},
 ]
 
 [package.extras]
@@ -3116,4 +3116,4 @@ typing = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "95e7271ca34faab49acda5670e0b01a2603139ec399b135288c210064027d0fd"
+content-hash = "3fb4a59568a6ee1cad78a8bafabc45db2730073b74817d9f652c07986d00de3c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ orjson = ">=3.11.6"
 pygments = ">=2.20.0"
 requests = ">=2.33.0"
 langsmith = ">=0.8.0"
+langgraph = ">=1.0.10"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "T201"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ pygments = ">=2.20.0"
 requests = ">=2.33.0"
 langsmith = ">=0.8.0"
 langgraph = ">=1.0.10"
+langgraph-checkpoint = ">=4.0.0"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "T201"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ json-repair = "^0.53.0"
 urllib3 = ">=2.7.0"
 orjson = ">=3.11.6"
 pygments = ">=2.20.0"
+requests = ">=2.33.0"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "T201"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ langchain-openai = "^1.0.2"
 json-repair = "^0.53.0"
 urllib3 = ">=2.7.0"
 orjson = ">=3.11.6"
+pygments = ">=2.20.0"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "T201"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ disallow_untyped_defs = true
 python = ">=3.10,<4.0"
 langchain = "^1.0.5"
 langchain-core = ">=1.4.0"
-langchain-openai = "^1.0.2"
+langchain-openai = "^1.1.14"
 json-repair = "^0.53.0"
 urllib3 = ">=2.7.0"
 orjson = ">=3.11.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ urllib3 = ">=2.7.0"
 orjson = ">=3.11.6"
 pygments = ">=2.20.0"
 requests = ">=2.33.0"
+langsmith = ">=0.8.0"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "T201"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ optional = true
 
 [tool.poetry.group.dev.dependencies]
 pytest-socket = "^0.7.0"
-python-dotenv = "^1.1.0"
+python-dotenv = "^1.2.2"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.4.3"
@@ -80,7 +80,7 @@ pytest-asyncio = "^0.23.2"
 pytest-socket = "^0.7.0"
 pytest-watcher = "^0.3.4"
 langchain-tests = "^0.3.5"
-python-dotenv = "^1.1.0"
+python-dotenv = "^1.2.2"
 
 [tool.poetry.group.codespell.dependencies]
 codespell = "^2.2.6"


### PR DESCRIPTION
## Summary

Incremental security-update branch. Each bump was applied, locked, installed, and validated against the **full integration test suite** (unit + `make integration_tests`) before commit. Bumps that broke the suite were reverted and are listed under **Deferred** for follow-up discussion.

## Landed (7 commits, one per bump)

| Package | Constraint added/changed | Resolved | Type |
|---|---|---|---|
| pygments | `>=2.20.0` (new direct) | 2.20.0 | transitive → direct security floor |
| python-dotenv | `^1.1.0` → `^1.2.2` (dev + test groups) | 1.2.2 | direct |
| requests | `>=2.33.0` (new direct) | 2.34.2 | transitive → direct security floor |
| langsmith | `>=0.8.0` (new direct) | 0.8.5 | transitive → direct security floor |
| langchain-openai | `^1.0.2` → `^1.1.14` | 1.2.1 (+ openai 2.7.1 → 2.37.0) | direct |
| langgraph | `>=1.0.10` (new direct) | 1.0.10 | transitive → direct security floor |
| langgraph-checkpoint | `>=4.0.0` (new direct) | 4.1.0 | transitive → direct security floor (unblocked by langgraph 1.0.10 lifting the `<4.0.0` cap) |

Each commit ran `make integration_tests` and reported **66 passed, 17 skipped, 0 failed**. Unit suite also clean (8 passed, 2 skipped).

Follows the pattern established by #43 (urllib3) and #44 (orjson): security floors for transitive deps get codified directly in `pyproject.toml` so they survive `poetry lock --regenerate`.

## Deferred (not in this PR)

**pytest cascade**: `pytest ^7.4.3 → ^9.0.3` plus the coordinated bumps it requires:
- `pytest-asyncio ^0.23.2 → ^1.3.0`
- `pytest-watcher ^0.3.4 → ^0.6.3`
- `langchain-tests ^0.3.5 → ^1.1.8`

The cascade locks and installs cleanly, and 68 of 70 integration tests pass under it. However, `langchain-tests 1.1.x` tightened `test_stream` / `test_astream` in `ChatModelIntegrationTests` to assert `len(full.content_blocks) == 1`. `ChatQwQ` legitimately emits **two** content blocks (`reasoning` + `text`) because reasoning content is surfaced via `additional_kwargs["reasoning_content"]`, which projects into a separate `reasoning` block in the v1 content protocol.

The base-class assertion has no opt-in flag (verified by reading `langchain_tests/integration_tests/chat_models.py` 1.1.8). The `TestChatQwQIntegration` test class is migrated from the upstream test suite and must not be modified.

Resolution paths to discuss separately:
1. Wait for / request an opt-in flag (e.g. `supports_reasoning_blocks`) in `langchain-tests`
2. Change `ChatQwQ` to fold reasoning into a single content block (behavior change for downstream users — not preferred)
3. Pin `langchain-tests` below 1.x indefinitely (defeats the purpose of bumping pytest)

## Test plan

- [x] Unit tests pass after each bump
- [x] `make integration_tests` passes after each landed bump
- [x] `make format` clean
- [x] `make lint`: 26 pre-existing mypy errors in `chat_models.py` (same as `main` — not introduced here)
- [x] Each landed bump is its own commit so any single one can be reverted if a regression surfaces later

🤖 Generated with [Claude Code](https://claude.com/claude-code)